### PR TITLE
Fixed wrong order of imports:

### DIFF
--- a/check/init.py
+++ b/check/init.py
@@ -1,11 +1,4 @@
-
 from mysqlsh.plugin_manager import plugin, plugin_function
-
-from check import trx
-from check import queries
-from check import locks
-from check import schema
-from check import other
 
 @plugin
 class check:
@@ -15,3 +8,9 @@ class check:
     A collection of tools and utilities to perform checks on your
     MySQL Database Server.
     """
+
+from check import trx
+from check import queries
+from check import locks
+from check import schema
+from check import other

--- a/collations/check.py
+++ b/collations/check.py
@@ -9,19 +9,19 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
 
 def _check_if_collation_exists(session, collation):
-   query = """SELECT COLLATION_NAME FROM INFORMATION_SCHEMA.COLLATIONS 
+   query = """SELECT COLLATION_NAME FROM INFORMATION_SCHEMA.COLLATIONS
               where COLLATION_NAME = '%s'""" % collation
    result = session.run_sql(query)
    if len(result.fetch_all()) == 1:
        return True
    return False
-    
+
 @plugin_function("collations.nonUnique")
 def non_unique(table, column, collation, schema=None, session=None):
     """
     Find non-unique values in a column for a given collation.
 
-    This function will list all the non-unique values in a column 
+    This function will list all the non-unique values in a column
     for a given collation.
 
     If no session is given, the current session of the MySQL Shell will be used.
@@ -38,7 +38,7 @@ def non_unique(table, column, collation, schema=None, session=None):
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
 
-    """    
+    """
     # Get hold of the global shell object
     import mysqlsh
     shell = mysqlsh.globals.shell

--- a/collations/init.py
+++ b/collations/init.py
@@ -3,8 +3,6 @@
 # Initializes the collations plugins.
 
 from mysqlsh.plugin_manager import plugin, plugin_function
-from collations import check
-from collations import outoforder
 
 @plugin
 class collations:
@@ -13,3 +11,6 @@ class collations:
 
     A collection of collation utilites.
     """
+
+from collations import check
+from collations import outoforder

--- a/demo/init.py
+++ b/demo/init.py
@@ -1,8 +1,6 @@
 # init.py
 # -------
 from mysqlsh.plugin_manager import plugin, plugin_function
-from demo import oracle8ball 
-
 
 @plugin
 class demo:
@@ -12,11 +10,13 @@ class demo:
     This plugin is used only for demo purpose.
     """
 
+from demo import oracle8ball
+
 @plugin_function("demo.helloWorld")
 def hello_world():
     """
     Simple function that prints "Hello world!"
-    
+
     Just say Hello World
 
     Returns:
@@ -33,7 +33,7 @@ def show_schemas(session=None):
     with the global session of the MySQL Shell.
 
     Args:
-        session (object): The optional session object used to query the 
+        session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
 
     Returns:

--- a/innodb/autoinc.py
+++ b/innodb/autoinc.py
@@ -7,13 +7,13 @@ def get_autoinc_fill(percentage=50, schema=None, session=None):
     Prints information about auto_increment fill up.
 
     Args:
-        percentage (integer): Only shows the tables where auto increments 
+        percentage (integer): Only shows the tables where auto increments
                               values are filled to at least % (default: 50).
-        schema (string): The name of the schema to use. This is optional.                              
+        schema (string): The name of the schema to use. This is optional.
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
-    
-    """    
+
+    """
     where_filter = ""
     having_filter = ""
 
@@ -86,9 +86,9 @@ def get_autoinc_fill(percentage=50, schema=None, session=None):
         TABLE_SCHEMA NOT IN ('mysql', 'INFORMATION_SCHEMA', 'performance_schema')
         AND EXTRA='auto_increment' {}
         {}
-        ORDER BY CAST(AUTO_INCREMENT_RATIO AS SIGNED INTEGER) 
+        ORDER BY CAST(AUTO_INCREMENT_RATIO AS SIGNED INTEGER)
         """.format(where_filter, having_filter)
-    
+
     run_and_show(stmt)
 
     return

--- a/innodb/bufferpool.py
+++ b/innodb/bufferpool.py
@@ -13,8 +13,8 @@ def get_tables_in_bp(session=None):
     Args:
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
-    
-    """  
+
+    """
     # Get hold of the global shell object
     import mysqlsh
     shell = mysqlsh.globals.shell
@@ -27,15 +27,15 @@ def get_tables_in_bp(session=None):
             return
     print("Processing, this can take a while (don't forget to run ANALYZE TABLE for accurate results)...")
 
-    stmt="""select variable_name, format_bytes(variable_value/1) 
-              from performance_schema.global_variables 
+    stmt="""select variable_name, format_bytes(variable_value/1)
+              from performance_schema.global_variables
               where variable_name = 'innodb_buffer_pool_size'"""
     bp_size = session.run_sql(stmt).fetch_one()[1]
-    stmt="""select variable_name, variable_value 
-              from performance_schema.global_variables 
+    stmt="""select variable_name, variable_value
+              from performance_schema.global_variables
               where variable_name = 'innodb_buffer_pool_instances'"""
     bp_instances = session.run_sql(stmt).fetch_one()[1]
-    
+
     if int(bp_instances) > 1:
         bp_instances_str = "%s instances" % bp_instances
     else:
@@ -43,21 +43,21 @@ def get_tables_in_bp(session=None):
 
     print("InnoDB Buffer Pool Size = %s (%s)" % (bp_size, bp_instances_str))
 
-    stmt="""SELECT t1.TABLE_NAME 'Table Name', COUNT(*) AS Pages,   
-                   format_bytes(SUM(IF(COMPRESSED_SIZE = 0, 16384, COMPRESSED_SIZE))) 
-                      AS 'Total Data in BP', 
-                   format_bytes(any_value(data_length)+any_value(index_length)) 
+    stmt="""SELECT t1.TABLE_NAME 'Table Name', COUNT(*) AS Pages,
+                   format_bytes(SUM(IF(COMPRESSED_SIZE = 0, 16384, COMPRESSED_SIZE)))
+                      AS 'Total Data in BP',
+                   format_bytes(any_value(data_length)+any_value(index_length))
                       'Total Table Size',
                    lpad(concat(round(SUM(IF(COMPRESSED_SIZE = 0, 16384, COMPRESSED_SIZE))
-                     /(any_value(data_length)+any_value(index_length)) * 100,2),'%'),"6"," ") 
-                       as 'in BP' 
-                   FROM INFORMATION_SCHEMA.INNODB_BUFFER_PAGE t1 
-                   JOIN INFORMATION_SCHEMA.TABLES t2 
-                     ON concat('`',t2.TABLE_SCHEMA,'`.`',t2.TABLE_NAME,'`') = t1.TABLE_NAME 
-                   WHERE t2.TABLE_SCHEMA  NOT IN ('mysql', 'sys')  
-                   GROUP BY t1.TABLE_NAME 
-                   ORDER BY SUM(IF(COMPRESSED_SIZE = 0, 16384, COMPRESSED_SIZE)) desc, 
-                                (any_value(data_length)+any_value(index_length)) desc""" 
+                     /(any_value(data_length)+any_value(index_length)) * 100,2),'%'),"6"," ")
+                       as 'in BP'
+                   FROM INFORMATION_SCHEMA.INNODB_BUFFER_PAGE t1
+                   JOIN INFORMATION_SCHEMA.TABLES t2
+                     ON concat('`',t2.TABLE_SCHEMA,'`.`',t2.TABLE_NAME,'`') = t1.TABLE_NAME
+                   WHERE t2.TABLE_SCHEMA  NOT IN ('mysql', 'sys')
+                   GROUP BY t1.TABLE_NAME
+                   ORDER BY SUM(IF(COMPRESSED_SIZE = 0, 16384, COMPRESSED_SIZE)) desc,
+                                (any_value(data_length)+any_value(index_length)) desc"""
     result = session.run_sql(stmt)
     shell.dump_rows(result)
     return

--- a/innodb/fragmented.py
+++ b/innodb/fragmented.py
@@ -4,7 +4,7 @@ from mysqlsh.plugin_manager import plugin, plugin_function
 def get_fragmented_tables(percentage=10, session=None):
     """
     Prints InnoDB fragmented tables.
-    
+
     This function prints the list of InnoDB Tables having free blocks.
 
     Args:
@@ -39,19 +39,19 @@ def get_fragmented_tables(percentage=10, session=None):
                     print("Changing information_schema_stats_expiry to 0 for this session only")
                     stmt = """SET information_schema_stats_expiry=0"""
                     result = session.run_sql(stmt)
-    stmt = """SELECT CONCAT(table_schema, '.', table_name) as 'TABLE', 
-       ENGINE, CONCAT(ROUND(table_rows / 1000000, 2), 'M') `ROWS`, 
-       CONCAT(ROUND(data_length / ( 1024 * 1024 * 1024 ), 2), 'G') DATA, 
-       CONCAT(ROUND(index_length / ( 1024 * 1024 * 1024 ), 2), 'G') IDX, 
-       CONCAT(ROUND(( data_length + index_length ) / ( 1024 * 1024 * 1024 ), 2), 'G') 'TOTAL SIZE', 
-       ROUND(index_length / data_length, 2)  IDXFRAC, 
+    stmt = """SELECT CONCAT(table_schema, '.', table_name) as 'TABLE',
+       ENGINE, CONCAT(ROUND(table_rows / 1000000, 2), 'M') `ROWS`,
+       CONCAT(ROUND(data_length / ( 1024 * 1024 * 1024 ), 2), 'G') DATA,
+       CONCAT(ROUND(index_length / ( 1024 * 1024 * 1024 ), 2), 'G') IDX,
+       CONCAT(ROUND(( data_length + index_length ) / ( 1024 * 1024 * 1024 ), 2), 'G') 'TOTAL SIZE',
+       ROUND(index_length / data_length, 2)  IDXFRAC,
         CONCAT(ROUND(( data_free / 1024 / 1024),2), 'MB') AS data_free,
        CONCAT('(',
-        IF(data_free< ( data_length + index_length ), 
+        IF(data_free< ( data_length + index_length ),
         CONCAT(round(data_free/(data_length+index_length)*100,2),'%'),
        '100%'),')') AS data_free_pct
        FROM information_schema.TABLES  WHERE (data_free/(data_length+index_length)*100) > {limit}
-       AND table_schema <> 'mysql';""".format(limit=percentage) 
+       AND table_schema <> 'mysql';""".format(limit=percentage)
     result = session.run_sql(stmt)
     shell.dump_rows(result)
     print ("Don't forget to run 'ANALYZE TABLE ...' for a more accurate result.")
@@ -60,13 +60,13 @@ def get_fragmented_tables(percentage=10, session=None):
 @plugin_function("innodb.getFragmentedTablesDisk")
 def get_fragmented_tables_disk(percentage=10, session=None):
     """
-    Prints InnoDB fragmented tables with disk info.        
+    Prints InnoDB fragmented tables with disk info.
 
     Args:
         percentage (integer): The amount of free space to be considered as fragmented (default: 10).
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
-    
+
     """
 
     import mysqlsh
@@ -94,17 +94,17 @@ def get_fragmented_tables_disk(percentage=10, session=None):
                else:
                     print("Changing information_schema_stats_expiry to 0 for this session only")
                     stmt = """SET information_schema_stats_expiry=0"""
-                    result = session.run_sql(stmt)        
-    stmt = """SELECT name NAME ,table_rows `ROWS`, format_bytes(data_length) DATA_SIZE, 
-                     format_bytes(index_length) INDEX_SIZE, 
-                     format_bytes(data_length+index_length) TOTAL_SIZE,        
-                     format_bytes(data_free) DATA_FREE, 
-                     format_bytes(FILE_SIZE) FILE_SIZE, 
+                    result = session.run_sql(stmt)
+    stmt = """SELECT name NAME ,table_rows `ROWS`, format_bytes(data_length) DATA_SIZE,
+                     format_bytes(index_length) INDEX_SIZE,
+                     format_bytes(data_length+index_length) TOTAL_SIZE,
+                     format_bytes(data_free) DATA_FREE,
+                     format_bytes(FILE_SIZE) FILE_SIZE,
                      format_bytes(FILE_SIZE - (data_length + index_length)) WASTED_SIZE,
                      CONCAT(round(((FILE_SIZE/100 - (data_length/100 + index_length/100))/(FILE_SIZE/100))*100,2),'%') 'FREE'
-              FROM information_schema.TABLES as t 
-              JOIN information_schema.INNODB_TABLESPACES as it 
-                ON it.name = concat(table_schema,"/",table_name) 
+              FROM information_schema.TABLES as t
+              JOIN information_schema.INNODB_TABLESPACES as it
+                ON it.name = concat(table_schema,"/",table_name)
              WHERE data_length > 20000
              AND ((FILE_SIZE/100 - (data_length/100 + index_length/100))/(FILE_SIZE/100))*100 > {limit}
           ORDER BY (data_length + index_length) desc""".format(limit=percentage)

--- a/innodb/init.py
+++ b/innodb/init.py
@@ -1,12 +1,7 @@
 # init.py
 # -------
 
-
 from mysqlsh.plugin_manager import plugin, plugin_function
-from innodb import fragmented
-from innodb import progress
-from innodb import bufferpool
-from innodb import autoinc
 
 @plugin
 class innodb:
@@ -14,5 +9,10 @@ class innodb:
     InnoDB management and utilities.
 
     A collection of InnoDB management tools and related
-    utilities that work on InnoDB Engine.    
+    utilities that work on InnoDB Engine.
    """
+
+from innodb import fragmented
+from innodb import progress
+from innodb import bufferpool
+from innodb import autoinc

--- a/innodb/progress.py
+++ b/innodb/progress.py
@@ -5,13 +5,13 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
 
 def _is_consumer_enabled(session, shell):
-     
+
     stmt = """select sys.ps_is_consumer_enabled("events_stages_current")"""
     result = session.run_sql(stmt)
     consumer = result.fetch_one()[0]
     ok = False
     if consumer == "NO":
-        answer = shell.prompt("""The consumer for 'events_stages_current' is not enabled, 
+        answer = shell.prompt("""The consumer for 'events_stages_current' is not enabled,
 do you want to enabled it now ? (y/N) """,
                               {'defaultValue':'n'})
         if answer.lower() == 'y':
@@ -22,10 +22,10 @@ do you want to enabled it now ? (y/N) """,
             ok = True
     else:
         ok = True
-    
+
     return ok
 
-def _are_instruments_enabled(session, shell):    
+def _are_instruments_enabled(session, shell):
 
     stmt = """SELECT NAME, ENABLED
          FROM performance_schema.setup_instruments
@@ -39,7 +39,7 @@ def _are_instruments_enabled(session, shell):
         for instrument in instruments:
             instruments_str += "%s, " % instrument[0]
 
-        answer = shell.prompt("""Some instruments are not enabled: %s 
+        answer = shell.prompt("""Some instruments are not enabled: %s
 Do you want to enabled them now ? (y/N) """
                               % instruments_str, {'defaultValue':'n'})
         if answer.lower() == 'y':
@@ -51,7 +51,7 @@ Do you want to enabled them now ? (y/N) """
             ok = True
     else:
         ok = True
-    
+
     return ok
 
 @plugin_function("innodb.getAlterProgress")
@@ -63,7 +63,7 @@ def get_alter_progress(format='table', session=None):
         format (string): The output format to be used (default: table).
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
-    
+
     """
 
     # Get hold of the global shell object
@@ -86,15 +86,15 @@ def get_alter_progress(format='table', session=None):
 
     stmt="""SELECT stmt.THREAD_ID, stmt.SQL_TEXT, stage.EVENT_NAME AS State,
                    stage.WORK_COMPLETED, stage.WORK_ESTIMATED,
-                   lpad(CONCAT(ROUND(100*stage.WORK_COMPLETED/stage.WORK_ESTIMATED, 2),"%"),12," ") 
+                   lpad(CONCAT(ROUND(100*stage.WORK_COMPLETED/stage.WORK_ESTIMATED, 2),"%"),12," ")
                    AS CompletedPct, lpad(format_pico_time(stmt.TIMER_WAIT), 10, " ") AS StartedAgo,
-                   current_allocated Memory           
-            FROM performance_schema.events_statements_current stmt                
-            INNER JOIN sys.memory_by_thread_by_current_bytes mt  
-                    ON mt.thread_id = stmt.thread_id 
-            INNER JOIN performance_schema.events_stages_current stage 
+                   current_allocated Memory
+            FROM performance_schema.events_statements_current stmt
+            INNER JOIN sys.memory_by_thread_by_current_bytes mt
+                    ON mt.thread_id = stmt.thread_id
+            INNER JOIN performance_schema.events_stages_current stage
                     ON stage.THREAD_ID = stmt.THREAD_ID"""
-    
+
     result = session.run_sql(stmt)
     shell.dump_rows(result, format)
     return

--- a/legacy_connect/init.py
+++ b/legacy_connect/init.py
@@ -1,10 +1,7 @@
 # init.py
 # -------
 
-
 from mysqlsh.plugin_manager import plugin, plugin_function
-from legacy_connect import mycnf
-
 
 @plugin
 class legacy_connect:
@@ -13,3 +10,5 @@ class legacy_connect:
 
     Plugin to connect to MySQL using the old my.cnf file.
     """
+
+from legacy_connect import mycnf

--- a/legacy_connect/mycnf.py
+++ b/legacy_connect/mycnf.py
@@ -36,9 +36,9 @@ def connect_with_mycnf(use_mysqlx=False, file=None):
             return
     import getpass
 
-    print("let's use info from %s to connect" % file)        
+    print("let's use info from %s to connect" % file)
     config = configparser.ConfigParser()
-    config.read(file)    
+    config.read(file)
     if not config.has_section('client'):
         print("ERROR: your my.cnf file should contain a section '[client]'")
         return
@@ -59,7 +59,7 @@ def connect_with_mycnf(use_mysqlx=False, file=None):
         port=config['client'].get('port', '3306')
         connection_dict = { "scheme": scheme, "user": user, "password": password, "host": hostname, "port": port }
         session = mysql.get_session(connection_dict)
-    
+
     shell.set_session(session)
-    
+
     return

--- a/schema/init.py
+++ b/schema/init.py
@@ -52,11 +52,6 @@
 #
 
 from mysqlsh.plugin_manager import plugin, plugin_function
-from schema import utils
-from schema import procedures
-from schema import defaults
-from schema import dates
-from schema import routines
 
 @plugin
 class schema_utils:
@@ -66,3 +61,9 @@ class schema_utils:
     A collection of schema management tools and related
     utilities that work on schemas.
     """
+
+from schema import utils
+from schema import procedures
+from schema import defaults
+from schema import dates
+from schema import routines

--- a/support/init.py
+++ b/support/init.py
@@ -1,5 +1,4 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
-from support import fetch
 
 @plugin
 class support:
@@ -9,3 +8,5 @@ class support:
     A collection of methods useful when requesting help such as support
     or Community Slack and Forums
     """
+
+from support import fetch


### PR DESCRIPTION
When the functions are declared on a different file and included on
the file that declares the class, the import must be done after the
class declaration. Otherwise, the help information won't be correctly
parsed.