### PR TITLE
define __returnDefaults

### DIFF
--- a/schema/defaults.py
+++ b/schema/defaults.py
@@ -1,4 +1,5 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
+from schema.utils import __returnDefaults
 
 @plugin_function("schema_utils.showDefaults")
 def show_defaults(table, schema=None, session=None):


### PR DESCRIPTION
Maybe I wrong but I didn't succeed to run:

Py > schema_utils.show_defaults('myTable','myDB')
Traceback (most recent call last):
  File "<string>", line 1, in <module>
RuntimeError: ScriptingError: schema_utils.show_defaults: User-defined function threw an exception: 
Traceback (most recent call last):
  File "/Users/yosik/.mysqlsh/plugins/schema/defaults.py", line 34, in show_defaults
    defaults = __returnDefaults(session, schema, table)
NameError: name '__returnDefaults' is not defined

I installed mysqlshell 8.0.23

After I added the row:
from schema.utils import __returnDefaults
it worked

Am I missing something?