### PR TITLE
Fix error from user.copy with MySQL 5.7

### DIFF
--- a/user/copy.py
+++ b/user/copy.py
@@ -201,7 +201,7 @@ def copy_users_grants(dryrun=False, ocimds=False, force=False, session=None):
                stmt = """SHOW CREATE USER `{}`@`{}`""".format(user[0], user[1])
                create_user = session.run_sql(stmt).fetch_one()[0] + ";"
                create_user=create_user.replace("CREATE USER '{}'@'".format(user[0]),"CREATE USER IF NOT EXISTS '{}'@'".format(user[0]))
-            if mysql_version != "8.0":
+            if mysql_version != "8.0" and mysql_version != "5.7":
                 if len(old_format) > 0:
                     # we need to find the password
                     stmt = "SELECT password FROM mysql.user WHERE user='{}' AND host='{}'".format(user[0], user[1])


### PR DESCRIPTION
When trying to copy a user between MySQL 5.7 servers the following error appears:

```
user.copy: User-defined function threw an exception: 
Traceback (most recent call last):
  File "/root/.mysqlsh/plugins/user/copy.py", line 205, in copy_users_grants
    if len(old_format) > 0:
TypeError: object of type 'NoneType' has no len()
 (ScriptingError)
```

It is because variable `old_format` is assigned value only when MySQL version is different than 8.0 and 5.7 (see around [line 101](https://github.com/lefred/mysqlshell-plugins/blob/0bf2a628b40060cd15da3df247fa8a169d18e88c/user/copy.py#L101)). So read its length later only in this case. With the modification there is no error and `CREATE USER`/`GRANT` statements are properly generated.