### PR TITLE
Supporting create router REST API user without shell prompt

### DIFF
--- a/router/init.py
+++ b/router/init.py
@@ -36,13 +36,15 @@ def create(uri):
 
 
 @plugin_function("router.createRestUser")
-def createRestUser(session=None):
+def createRestUser(restUsername=None, restUserPassword=None, session=None):
     """
     Create the MySQL Router REST API user in MySQL MetaData.
 
     Args:
         session (object): The optional session object used to query the
             database. If omitted the MySQL Shell's current session will be used.
+        restUsername (string): The optional username.
+        restUserPassword (string): The optional password.
     """
 
     use_passlib = False
@@ -80,15 +82,19 @@ def createRestUser(session=None):
            print("ERROR: this is not a valid MySQL Server, no mysql_innodb_cluster_metada found!")
            return
     #get the current user connected
-    username = shell.prompt("Enter the username: ")
-    nok=True
-    while nok:
-        userpassword = shell.prompt("Enter the password: ",{'type': 'password'})
-        userpassword_check = shell.prompt("Enter the password again: ",{'type': 'password'})
-        if userpassword == userpassword_check:
-            nok=False
-        else:
-            print("Passwords do not match, try again !")
+    if restUsername is not None and restUserPassword is not None:
+      username = restUsername
+      userpassword = restUserPassword
+    else:
+      username = shell.prompt("Enter the username: ")
+      nok=True
+      while nok:
+          userpassword = shell.prompt("Enter the password: ",{'type': 'password'})
+          userpassword_check = shell.prompt("Enter the password again: ",{'type': 'password'})
+          if userpassword == userpassword_check:
+              nok=False
+          else:
+              print("Passwords do not match, try again !")
 
     if use_passlib:
         crypted_pwd = sha256_crypt.hash(userpassword)


### PR DESCRIPTION
Allow user to create MySQL Router REST API user without asking the user to enter a username and password. Users can automate MySQL Router REST API user account creation via Ansible.