### PR TITLE
Add heatwave_utils plugin

### DIFF
--- a/heatwave_utils/comm.py
+++ b/heatwave_utils/comm.py
@@ -1,0 +1,52 @@
+def __getHeatWaveStatus(session=None):
+
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    result = session.run_sql("""
+        select 
+            max(    case variable_name    when 'rapid_service_status' then variable_value    else ''    end ) as rapid_service_status, 
+            max(    case variable_name    when 'rapid_cluster_status' then variable_value    else ''    end ) as rapid_cluster_status,
+            max(    case variable_name    when 'rapid_plugin_bootstrapped' then variable_value    else ''    end ) as rapid_plugin_bootstrapped
+        from performance_schema.global_status where variable_name like 'rapid%'
+    """ )
+
+    if (result.get_warnings_count() > 0):
+        # Bail out and print the warnings
+        print("Warnings occurred - bailing out:")
+        print(result.get_warnings())
+        return False
+
+
+    rows = result.fetch_all()
+    return rows
+
+def __isHeatWaveOnline(session=None):
+
+    rows = __getHeatWaveStatus(session)
+    if len(rows) > 0 and rows[0][0] == "ONLINE":
+        return True
+
+    print("Heatwave is OFFLINE")
+    return False
+
+def __isHeatWavePlugin(session=None):
+
+    rows = __getHeatWaveStatus(session)
+    
+    if len(rows) > 0 :
+        if rows[0][2] == "NO":
+            print("Heatwave Plugin not installed")
+            return False
+        else:
+            return True
+
+    return False
+

--- a/heatwave_utils/init.py
+++ b/heatwave_utils/init.py
@@ -1,4 +1,6 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
+from heatwave_utils.comm import __isHeatWaveOnline, __isHeatWavePlugin
+
 @plugin
 class heatwave_utils:
     """
@@ -112,12 +114,17 @@ def list_sec_loaded_tables(schema=None, session=None):
     if schema is None:
         print("No schema specified.")
         return
-	
-    db = session.get_schema(schema)
 
-    tables = __returnSecLoadedTables(session, schema)
+    if __isHeatWavePlugin(session) is False:
+        print("No HeatWave Plugin")
+        return
 
-    return tables;
+    if __isHeatWaveOnline(session) :
+        db = session.get_schema(schema)
+        tables = __returnSecLoadedTables(session, schema)
+        return tables;
+
+    return
 
 @plugin_function("heatwave_utils.list_secondary_engine_tables")
 def list_sec_engine_tables(schema=None, session=None):
@@ -144,11 +151,14 @@ def list_sec_engine_tables(schema=None, session=None):
         print("No schema specified.")
         return
 	
-    db = session.get_schema(schema)
-
-    tables = __returnSecEngineTables(session, schema)
-
-    return tables;
+    if __isHeatWavePlugin(session) is False:
+        print("No HeatWave Plugin")
+        return
+    if __isHeatWaveOnline(session) :
+        db = session.get_schema(schema)
+        tables = __returnSecEngineTables(session, schema)
+        return tables;
+    return
 
 
 @plugin_function("heatwave_utils.unload_schema")
@@ -177,13 +187,17 @@ def unload_schema(schema=None, session=None):
         print("No schema specified.")
         return
 	
-    db = session.get_schema(schema)
-    session.set_current_schema(schema)
-    table = __returnSecLoadedTables(session, schema)
-    for i in table:
-        print('alter table ' + i + ' secondary_unload')
-        result = session.run_sql('alter table ' + i + ' secondary_unload')
-        shell.dump_rows(result)
+    if __isHeatWavePlugin(session) is False:
+        print("No HeatWave Plugin")
+        return
+    if __isHeatWaveOnline(session) :
+        db = session.get_schema(schema)
+        session.set_current_schema(schema)
+        table = __returnSecLoadedTables(session, schema)
+        for i in table:
+            print('alter table ' + i + ' secondary_unload')
+            result = session.run_sql('alter table ' + i + ' secondary_unload')
+            shell.dump_rows(result)
 
 
     return
@@ -215,6 +229,10 @@ def unset_schema(schema=None, session=None):
         print("No schema specified.")
         return
 	
+    if __isHeatWavePlugin(session) is False:
+        print("No HeatWave Plugin")
+        return
+
     db = session.get_schema(schema)
     session.set_current_schema(schema)
     table = __returnSecEngineTables(session, schema)
@@ -251,11 +269,12 @@ def load_schema(schema=None, session=None):
     if schema is None:
         print("No schema specified.")
         return
-	
-    db = session.get_schema(schema)
-    session.set_current_schema(schema)
-    result = __loadSecTables(session, schema)
-    shell.dump_rows(result)
+
+    if __isHeatWavePlugin(session) :
+        db = session.get_schema(schema)
+        session.set_current_schema(schema)
+        result = __loadSecTables(session, schema)
+        shell.dump_rows(result)
 
     return
 

--- a/heatwave_utils/init.py
+++ b/heatwave_utils/init.py
@@ -1,0 +1,315 @@
+from mysqlsh.plugin_manager import plugin, plugin_function
+@plugin
+class heatwave_utils:
+    """
+    Heatwave Utils 
+
+    A collection of utils to manage heatwavse
+    """
+
+# internal function to execute SQL in the current session and return RESULTSET
+def __runAndReturn(session, sqltext=None) :
+    stmt = ""
+    if sqltext is not None:
+        stmt = sqltext;
+        stmt = stmt + ";"
+
+    # Execute the query and check for warnings
+    result = session.run_sql(stmt)
+    if (result.get_warnings_count() > 0):
+        # Bail out and print the warnings
+        print("Warnings occurred - bailing out:")
+        print(result.get_warnings())
+        return False
+
+    return result;
+
+# internal function to Load call sys.heatwave_load(....) for single schema
+def __loadSecTables(session, schema):
+   
+    # Define the query to get the routines
+    if schema is not None:
+        stmt = "call sys.heatwave_load(JSON_ARRAY('%s'), null)" % schema
+        stmt = stmt + ";"
+
+
+    # Execute the query and check for warnings
+    result = __runAndReturn(session, stmt)
+
+    return result;
+
+# internal function to return array of Table name with SECONDARY_ENGINE=RAPID
+def __returnSecEngineTables(session, schema):
+   
+    # Define the query to get the routines
+    stmt = "select table_schema, table_name, create_options from information_schema.tables t where create_options like '%SECONDARY_ENGINE=%RAPID%'"
+
+    if schema is not None:
+       stmt  = stmt + " AND t.table_schema='%s'" % schema
+
+    stmt = stmt + ";"
+    # Execute the query and check for warnings
+    result = session.run_sql(stmt)
+    tables = result.fetch_all()
+    if (result.get_warnings_count() > 0):
+        # Bail out and print the warnings
+        print("Warnings occurred - bailing out:")
+        print(result.get_warnings())
+        return False
+    tablearray = []
+    for row in tables:
+        tablearray.append( row[1] )
+
+    return tablearray;
+
+
+# internal function to return an array of table name with SECONDARY ENGINE loaded.
+def __returnSecLoadedTables(session, schema):
+   
+    # Define the query to get the routines
+
+    stmt = "select t.schema_name, t.table_name from performance_schema.rpd_tables a , performance_schema.rpd_table_id t where a.id = t.id "
+    if schema is not None:
+       stmt  = stmt + " AND t.schema_name='%s'" % schema
+
+    stmt = stmt + ";"
+    # Execute the query and check for warnings
+    result = session.run_sql(stmt)
+    tables = result.fetch_all()
+    if (result.get_warnings_count() > 0):
+        # Bail out and print the warnings
+        print("Warnings occurred - bailing out:")
+        print(result.get_warnings())
+        return False
+    tablearray = []
+    for row in tables:
+        tablearray.append( row[1] )
+
+    return tablearray;
+
+
+@plugin_function("heatwave_utils.list_secondary_loaded_tables")
+def list_sec_loaded_tables(schema=None, session=None):
+    """
+    Wizard to list secondary engine with data loaded tables 
+
+    Args:
+        schema (string): The session to be used on the operation.
+        session (object): The optional session object
+
+    """
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    if schema is None:
+        print("No schema specified.")
+        return
+	
+    db = session.get_schema(schema)
+
+    tables = __returnSecLoadedTables(session, schema)
+
+    return tables;
+
+@plugin_function("heatwave_utils.list_secondary_engine_tables")
+def list_sec_engine_tables(schema=None, session=None):
+    """
+    Wizard to list tables with secondary engine
+
+    Args:
+        schema (string): The session to be used on the operation.
+        session (object): The optional session object
+
+    """
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    if schema is None:
+        print("No schema specified.")
+        return
+	
+    db = session.get_schema(schema)
+
+    tables = __returnSecEngineTables(session, schema)
+
+    return tables;
+
+
+@plugin_function("heatwave_utils.unload_schema")
+def unload_schema(schema=None, session=None):
+    """
+    Wizard to unload secondary_engine for tables in schema
+
+    Args:
+        schema (string): The session to be used on the operation.
+        session (object): The optional session object
+
+    """
+
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    if schema is None:
+        print("No schema specified.")
+        return
+	
+    db = session.get_schema(schema)
+    session.set_current_schema(schema)
+    table = __returnSecLoadedTables(session, schema)
+    for i in table:
+        print('alter table ' + i + ' secondary_unload')
+        result = session.run_sql('alter table ' + i + ' secondary_unload')
+        shell.dump_rows(result)
+
+
+    return
+
+
+@plugin_function("heatwave_utils.unset_schema")
+def unset_schema(schema=None, session=None):
+    """
+    Wizard to unset secondary_engine for tables in schema
+
+    Args:
+        schema (string): The session to be used on the operation.
+        session (object): The optional session object
+
+    """
+
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    if schema is None:
+        print("No schema specified.")
+        return
+	
+    db = session.get_schema(schema)
+    session.set_current_schema(schema)
+    table = __returnSecEngineTables(session, schema)
+    for i in table:
+        print('alter table ' + i + ' secondary_engine=null')
+        result = session.run_sql('alter table ' + i + ' secondary_engine=null')
+        shell.dump_rows(result)
+
+
+    return
+
+@plugin_function("heatwave_utils.load_schema")
+def load_schema(schema=None, session=None):
+    """
+    Wizard to unset secondary_engine for tables in schema
+
+    Args:
+        schema (string): The session to be used on the operation.
+        session (object): The optional session object
+
+    """
+
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    if schema is None:
+        print("No schema specified.")
+        return
+	
+    db = session.get_schema(schema)
+    session.set_current_schema(schema)
+    result = __loadSecTables(session, schema)
+    shell.dump_rows(result)
+
+    return
+
+@plugin_function("heatwave_utils.set_trace_on")
+def set_trace_on( session=None):
+    """
+    Wizard to set trace on
+
+    Args:
+        session (object): The optional session object
+
+    """
+
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    result = __runAndReturn(session, "SET SESSION optimizer_trace='enabled=on';")
+    result = __runAndReturn(session, "SET optimizer_trace_offset=-2;")
+    shell.dump_rows(result)
+
+    return
+
+@plugin_function("heatwave_utils.set_trace_off")
+def set_trace_off( session=None):
+    """
+    Wizard to set trace off
+
+    Args:
+        session (object): The optional session object
+
+    """
+
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    result = __runAndReturn(session, "SET SESSION optimizer_trace='enabled=off';")
+    shell.dump_rows(result)
+
+    return
+
+from heatwave_utils import reports

--- a/heatwave_utils/reports.py
+++ b/heatwave_utils/reports.py
@@ -1,0 +1,81 @@
+from mysqlsh.plugin_manager import plugin, plugin_function
+
+def __returnQueryStats(session):
+   
+    # Define the query to get the routines
+    stmt = """SELECT query_id, left(query_text,40),
+       JSON_EXTRACT(JSON_UNQUOTE(qkrn_text->'$**.sessionId'),'$[0]') AS session_id,
+       JSON_EXTRACT(JSON_UNQUOTE(qkrn_text->'$**.totalBaseDataScanned'), '$[0]') AS data_scanned, 
+       JSON_EXTRACT(JSON_UNQUOTE(qexec_text->'$**.error'),'$[0]') AS error_message 
+       FROM performance_schema.rpd_query_stats
+    """
+
+
+    stmt = stmt + ";"
+    # Execute the query and check for warnings
+    result = session.run_sql(stmt)
+    return result;
+
+def __returnTraceInfo(session):
+   
+    # Define the query to get the routines
+    stmt = "SELECT QUERY, TRACE->'$**.Rapid_Offload_Fails' FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE"
+
+
+    stmt = stmt + ";"
+    # Execute the query and check for warnings
+    result = session.run_sql(stmt)
+    return result;
+
+
+
+
+@plugin_function("heatwave_utils.report_query_stats")
+def report_query_stats(session=None):
+    """
+    Wizard to report query stats
+
+    Args:
+        session (object): The optional session object
+
+    """
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    result= __returnQueryStats(session )
+    shell.dump_rows(result) 
+
+    return ;
+
+@plugin_function("heatwave_utils.report_trace_info")
+def report_trace_info(session=None):
+    """
+    Wizard to report trace info
+
+    Args:
+        session (object): The optional session object
+
+    """
+    # Get hold of the global shell object
+    import mysqlsh
+    shell = mysqlsh.globals.shell
+
+    if session is None:
+        session = shell.get_session()
+        if session is None:
+            print("No session specified. Either pass a session object to this "
+                  "function or connect the shell to a database")
+            return
+
+    result= __returnTraceInfo(session )
+    shell.dump_rows(result) 
+
+    return ;

--- a/heatwave_utils/reports.py
+++ b/heatwave_utils/reports.py
@@ -1,4 +1,5 @@
 from mysqlsh.plugin_manager import plugin, plugin_function
+from heatwave_utils.comm import __isHeatWaveOnline, __isHeatWavePlugin
 
 def __returnQueryStats(session):
    
@@ -21,12 +22,10 @@ def __returnTraceInfo(session):
     # Define the query to get the routines
     stmt = "SELECT QUERY, TRACE->'$**.Rapid_Offload_Fails' FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE"
 
-
     stmt = stmt + ";"
     # Execute the query and check for warnings
     result = session.run_sql(stmt)
     return result;
-
 
 
 
@@ -50,8 +49,9 @@ def report_query_stats(session=None):
                   "function or connect the shell to a database")
             return
 
-    result= __returnQueryStats(session )
-    shell.dump_rows(result) 
+    if __isHeatWaveOnline(session)  :
+        result= __returnQueryStats(session )
+        shell.dump_rows(result) 
 
     return ;
 
@@ -63,6 +63,8 @@ def report_trace_info(session=None):
     Args:
         session (object): The optional session object
 
+    import mysqlsh
+    shell = mysqlsh.globals.shell
     """
     # Get hold of the global shell object
     import mysqlsh
@@ -75,7 +77,8 @@ def report_trace_info(session=None):
                   "function or connect the shell to a database")
             return
 
-    result= __returnTraceInfo(session )
-    shell.dump_rows(result) 
+    if __isHeatWaveOnline(session)  :
+        result= __returnTraceInfo(session)
+        shell.dump_rows(result) 
 
     return ;


### PR DESCRIPTION
The heatwave_utils is revised to include :  (Those are the things we usually use in HW..)
load_schema, unload_schema, unset_schema,
list_secondary_engine_tables, list_secondary_loaded_tables
report_query_stats
set_trace_on, set_trace_off, report_trace_info