### PR TITLE
Support nodes in RECOVERY state

### DIFF
--- a/innodb_cluster/secondary.py
+++ b/innodb_cluster/secondary.py
@@ -134,7 +134,11 @@ def show_speed(limit=10, session=None):
                            performance_schema.replication_connection_status AS conn_status
                            JOIN performance_schema.replication_applier_status_by_worker AS applier_status
                            ON applier_status.channel_name = conn_status.channel_name
-                           WHERE conn_status.channel_name='group_replication_applier'"""
+                           WHERE conn_status.channel_name=if( 
+                                                (SELECT group_members.MEMBER_STATE 
+                                                   FROM performance_schema.replication_group_members AS group_members 
+                                                   WHERE member_id=@@global.server_uuid) = 'RECOVERING', 
+                                                        'group_replication_recovery', 'group_replication_applier')"""
             result = secondary_sessions[secondary].run_sql(stmt)
             row = result.fetch_one()
             out = "%s	%s       %s       %s	%s	%s	%s	%s" % (secondary, row[0].split(


### PR DESCRIPTION
Without this patch, the plugin fails with:
``` MySQL  127.0.0.1:33060+ ssl  JS > innodb_cluster.showGroupReplicationSpeed();
======================================================================================================
MySQL InnoDB Cluster : Group Replication Information
======================================================================================================
                SeqNo     SeqNo
                Last      Last                  transport       time to                         Lag
Host            QueueTx   ApplyTx  repl delay   time            RelayLog        apply time      in sec
------------------------------------------------------------------------------------------------------
10.124.33.170:3306      1284292       1284292       0.005495    0.001848        0.000019        0.003520        0
10.124.33.176:3306      1284292       1284292       0.028815    0.002524        0.000022        0.026172        0
innodb_cluster.showGroupReplicationSpeed: User-defined function threw an exception:
Traceback (most recent call last):
  File "/root/.mysqlsh/plugins/innodb_cluster/secondary.py", line 140, in show_speed
    out = "%s   %s       %s       %s    %s      %s      %s      %s" % (secondary, row[0].split(':')[1], row[1].split(':')[1], row[2], row[3], row[4], row[5], row[6])
IndexError: list index out of range
 (ScriptingError)

```

If failed on third entry; This was due to  row[0] not containing the expected gtid sequence, because the node was in recovery, and thus the group_replication_applier channel has no trx info; The patch checks member state and get information from correct channel

Results
```======================================================================================================
MySQL InnoDB Cluster : Group Replication Information
======================================================================================================                SeqNo     SeqNo
                Last      Last                  transport       time to                         Lag
Host            QueueTx   ApplyTx  repl delay   time            RelayLog        apply time      in sec
------------------------------------------------------------------------------------------------------
10.124.33.170:3306      1284292       1284292       0.005495    0.001848        0.000019        0.003520        0
10.124.33.176:3306      1284292       1284292       0.028815    0.002524        0.000022        0.026172        0
10.124.33.36:3306       1284292       955625       26428.160537 0.006152        0.001871        0.008995        8668
10.124.33.88:3306       1284292       1284292       0.010893    0.001659        0.000019        0.009112        0

10.124.33.170:3306      1284292       1284292       0.005495    0.001848        0.000019        0.003520        0
10.124.33.176:3306      1284292       1284292       0.028815    0.002524        0.000022        0.026172        0
10.124.33.36:3306       1284292       955887       26425.005305 0.006152        0.001871        0.007506        0
10.124.33.88:3306       1284292       1284292       0.010893    0.001659        0.000019        0.009112        0

10.124.33.170:3306      1284292       1284292       0.005495    0.001848        0.000019        0.003520        0
10.124.33.176:3306      1284292       1284292       0.028815    0.002524        0.000022        0.026172        0
10.124.33.36:3306       1284292       956123       26425.049696 0.006152        0.001871        0.048876        8664
10.124.33.88:3306       1284292       1284292       0.010893    0.001659        0.000019        0.009112        0

```